### PR TITLE
Add GitHub workflow to create and upload binary as release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,42 @@ jobs:
 
       - name: Run tests
         run: cargo test
+
+  release:
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.sha }}
+          release_name: Release ${{ github.sha }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./target/release/opml-manager
+          asset_name: opml-manager
+          asset_content_type: application/octet-stream

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           profile: minimal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,10 @@ jobs:
           draft: false
           prerelease: false
 
+      - name: Set executable permissions
+        run: chmod +x opml-manager
+
       - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./target/release/opml-manager
-          asset_name: opml-manager
-          asset_content_type: application/octet-stream
+          files: opml-manager

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,15 +49,18 @@ jobs:
 
       - name: Create GitHub Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.sha }}
-          release_name: Release ${{ github.sha }}
+          name: ${{ github.ref_name }}
+          body: |
+            Release ${{ github.ref_name }}
+            
+            Changes in this release:
+            ${{ github.event.head_commit.message }}
           draft: false
           prerelease: false
-
       - name: Set executable permissions
         run: chmod +x opml-manager
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ url = "2.5"
 chrono = "0.4"
 futures = "0.3"
 thiserror = "1.0"
+actions/upload-release-asset = "1.0"
+actions/create-release = "1.0"
 
 [dev-dependencies]
 cargo-make = "0.32.0"


### PR DESCRIPTION
Add a GitHub workflow to create a binary from `cargo build --release` and upload it as a GitHub release.

* **Cargo.toml**
  - Add `actions/upload-release-asset` and `actions/create-release` as dependencies.

* **.github/workflows/ci.yml**
  - Add a new job `release` after the existing `test` job.
  - Add steps in the `release` job to build the binary using `cargo build --release`.
  - Add steps in the `release` job to create a GitHub release using `actions/create-release`.
  - Add steps in the `release` job to upload the binary using `actions/upload-release-asset`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/opml-manager/pull/2?shareId=5bdd6da0-be09-4594-9cf6-6128feae4342).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new release job in the CI workflow that builds and publishes the application after tests pass.
	- Added new dependencies for release asset management.

- **Chores**
	- Updated the project dependencies to include new actions for creating and uploading releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->