### PR TITLE
Fix inconsistent URL normalization in deduplication logic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,17 @@ use opml_manager::opml::{generate_opml, parse_opml};
 use opml_manager::report::{format_markdown_report, generate_summary};
 use opml_manager::validation::validate_feed;
 
+fn normalize_url(url: &str) -> String {
+    let mut normalized_url = url.to_lowercase();
+    if normalized_url.ends_with('/') {
+        normalized_url.pop();
+    }
+    if normalized_url.starts_with("http://") {
+        normalized_url = normalized_url.replacen("http://", "https://", 1);
+    }
+    normalized_url
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let cli = Cli::parse();
@@ -53,7 +64,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             let mut seen = std::collections::HashSet::new();
 
             for feed in feeds {
-                if seen.insert(feed.xml_url.to_lowercase()) {
+                if seen.insert(normalize_url(&feed.xml_url)) {
                     unique_feeds.push(feed);
                 }
             }

--- a/tests/opml_parsing.rs
+++ b/tests/opml_parsing.rs
@@ -99,7 +99,7 @@ fn test_large_opml() {
     content.push_str("</body></opml>");
 
     let feeds = parse_opml(&content).unwrap();
-    assert_eq!(feeds.len(), 10_000);
+    assert_eq!(feeds.len(), 10,000);
 }
 
 #[test]
@@ -109,4 +109,21 @@ fn test_invalid_utf8_sequences() {
 
     let result = parse_opml(content);
     assert!(result.is_err());
+}
+
+#[test]
+fn test_url_normalization() {
+    let content = r#"<?xml version="1.0" encoding="UTF-8"?>
+    <opml version="2.0">
+        <head><title>Normalization Test</title></head>
+        <body>
+            <outline type="rss" text="Feed 1" xmlUrl="http://example.com/feed"/>
+            <outline type="rss" text="Feed 2" xmlUrl="http://example.com/feed/"/>
+            <outline type="rss" text="Feed 3" xmlUrl="https://example.com/feed"/>
+            <outline type="rss" text="Feed 4" xmlUrl="http://example.com/FEED"/>
+        </body>
+    </opml>"#;
+
+    let feeds = parse_opml(content).unwrap();
+    assert_eq!(feeds.len(), 1); // All URLs should be normalized to the same value
 }

--- a/tests/opml_parsing.rs
+++ b/tests/opml_parsing.rs
@@ -1,5 +1,5 @@
-use opml_manager::opml::parse_opml;
 use opml_manager::error::OPMLError;
+use opml_manager::opml::parse_opml;
 
 #[test]
 fn test_parse_empty_opml() {
@@ -47,16 +47,19 @@ fn test_missing_required_attributes() {
 
 #[test]
 fn test_deeply_nested_categories() {
-    let mut content = String::from(r#"<?xml version="1.0" encoding="UTF-8"?>
+    let mut content = String::from(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
     <opml version="2.0">
         <head><title>Test</title></head>
-        <body>"#);
-    
+        <body>"#,
+    );
+
     // Create 101 levels of nesting
     for i in 0..101 {
         content.push_str(&format!("<outline text=\"Category{}\">", i));
     }
-    content.push_str(r#"<outline type="rss" text="Deep Feed" xmlUrl="http://example.com/feed.xml"/>"#);
+    content
+        .push_str(r#"<outline type="rss" text="Deep Feed" xmlUrl="http://example.com/feed.xml"/>"#);
     for _ in 0..101 {
         content.push_str("</outline>");
     }
@@ -84,11 +87,13 @@ fn test_malformed_category_structure() {
 
 #[test]
 fn test_large_opml() {
-    let mut content = String::from(r#"<?xml version="1.0" encoding="UTF-8"?>
+    let mut content = String::from(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
     <opml version="2.0">
         <head><title>Large Test</title></head>
-        <body>"#);
-    
+        <body>"#,
+    );
+
     // Add 10,000 feeds
     for i in 0..10_000 {
         content.push_str(&format!(
@@ -99,7 +104,7 @@ fn test_large_opml() {
     content.push_str("</body></opml>");
 
     let feeds = parse_opml(&content).unwrap();
-    assert_eq!(feeds.len(), 10,000);
+    assert_eq!(feeds.len(), 10_000);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #4

Add URL normalization to deduplication logic in `src/main.rs`.

* **Normalization Function**: Add a `normalize_url` function to handle URL normalization, including converting to lowercase, removing trailing slashes, and replacing "http" with "https".
* **Deduplication Update**: Update the deduplication logic to use the `normalize_url` function for URL comparison.
* **Test Case**: Add a test case in `tests/opml_parsing.rs` to verify URL normalization in deduplication.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/opml-manager/pull/18?shareId=181b32bc-663c-40a4-ad85-ac7dfeab62a9).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced URL normalization to standardize URLs in the feed processing.
	- Enhanced error handling and deduplication logic for feed nodes.

- **Bug Fixes**
	- Improved robustness of feed parsing by preventing duplicate feeds based on normalized URLs.

- **Tests**
	- Added a new test case for URL normalization in OPML content.
	- Improved readability of existing test cases without altering their logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->