### PR TITLE
Implement streaming OPML parsing using xmlparser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,6 +1560,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "url",
+ "xmlparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ url = "2.5"
 chrono = "0.4"
 futures = "0.3"
 thiserror = "1.0"
+xmlparser = "0.13.6"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,9 @@ pub enum OPMLError {
     #[error("XML parsing error: {0}")]
     XMLParsing(#[from] roxmltree::Error),
 
+    #[error("XML parser error: {0}")]
+    XMLParser(String),
+
     #[error("HTTP error: {0}")]
     Http(#[from] reqwest::Error),
 


### PR DESCRIPTION
Fixes #5

Refactor OPML file processing to use streaming and event-based XML parsing.

* Replace `roxmltree::Document::parse` with `xmlparser::Tokenizer` for event-based XML parsing in `parse_opml` function.
* Refactor `process_outline` function to handle XML events instead of loading the entire document into memory.
* Remove the recursive processing of outline nodes and replace it with event-based processing.
* Update the logic to handle XML attributes and element start/end events to build `Feed` structs.
* Remove unused imports and update existing ones.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/opml-manager/pull/19?shareId=aefc82d8-428f-4878-a89d-a70915bf2de8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new error type for XML parsing in the error handling system.

- **Bug Fixes**
	- Improved error reporting capabilities with the addition of a specific error variant.

- **Chores**
	- Updated project dependencies, including the addition of `xmlparser` and an update to `indicatif`.
	- Removed an unused function related to OPML content generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->