### PR TITLE
Add progress bar for feed validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
  "bitflags 1.3.2",
  "strsim 0.8.0",
  "textwrap",
- "unicode-width",
+ "unicode-width 0.1.14",
  "vec_map",
 ]
 
@@ -378,6 +378,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
+version = "0.15.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -553,6 +566,12 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1275,6 +1294,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width 0.2.0",
+ "web-time",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,6 +1517,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,6 +1589,7 @@ dependencies = [
  "chrono",
  "clap 4.5.23",
  "futures",
+ "indicatif",
  "mockito",
  "reqwest",
  "roxmltree",
@@ -1625,6 +1664,12 @@ name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "portable-atomic"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "powerfmt"
@@ -2209,7 +2254,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -2407,6 +2452,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2578,6 +2629,16 @@ name = "web-sys"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ url = "2.5"
 chrono = "0.4"
 futures = "0.3"
 thiserror = "1.0"
+indicatif = "0.17.9"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ For more options, use:
 cargo run --release -- --help
 ```
 
+### Progress Bar for Feed Validation
+The OPML Manager now includes a progress bar for feed validation to provide users with real-time updates on the validation process. This feature is especially useful for long-running operations.
+
 ## ⚙️ Tech Info
 The OPML Manager is built using Rust and leverages several libraries:
 - **Clap**: For parsing command-line arguments.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 use clap::Parser;
 use futures::future::join_all;
+use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::Client;
 use std::error::Error;
 use std::fs;
 use std::path::Path;
 use std::time::Duration;
-use indicatif::{ProgressBar, ProgressStyle};
 
 use opml_manager::cli::{Cli, Commands};
 use opml_manager::opml::{generate_opml, parse_opml};
@@ -83,6 +83,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             let pb = ProgressBar::new(feeds.len() as u64);
             pb.set_style(ProgressStyle::default_bar()
                 .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({eta})")
+                .expect("Failed to create progress bar template")
                 .progress_chars("#>-"));
 
             for feed in &feeds {
@@ -194,6 +195,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 let pb = ProgressBar::new(feeds.len() as u64);
                 pb.set_style(ProgressStyle::default_bar()
                     .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({eta})")
+                    .expect("Failed to create progress bar template")
                     .progress_chars("#>-"));
 
                 for feed in &feeds {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,8 @@
 use opml_manager::Feed;
-use tokio::runtime::Runtime;
-use std::collections::{HashMap, HashSet};
 
+use tokio::runtime::Runtime;
+
+#[allow(dead_code)]
 pub fn get_test_runtime() -> Runtime {
     Runtime::new().unwrap()
 }
@@ -9,7 +10,7 @@ pub fn get_test_runtime() -> Runtime {
 pub fn create_test_feed(title: &str, url: &str) -> Feed {
     Feed::new(title.to_string(), url.to_string(), None, vec![])
 }
-
+#[allow(dead_code)]
 pub fn create_test_feed_with_categories(title: &str, url: &str, categories: Vec<&str>) -> Feed {
     Feed::new(
         title.to_string(),
@@ -19,6 +20,7 @@ pub fn create_test_feed_with_categories(title: &str, url: &str, categories: Vec<
     )
 }
 
+#[allow(dead_code)]
 pub fn extract_domain(url: &str) -> String {
     url.replace("http://", "")
         .replace("https://", "")

--- a/tests/report_generation.rs
+++ b/tests/report_generation.rs
@@ -1,4 +1,4 @@
-use crate::common::{create_test_feed, create_test_feed_with_categories, extract_domain};
+use crate::common::{create_test_feed, create_test_feed_with_categories};
 use opml_manager::report::format_markdown_report;
 use opml_manager::Feed;
 use std::collections::{HashMap, HashSet};


### PR DESCRIPTION
Fixes #6

Add progress bar for feed validation using the `indicatif` crate.

* **README.md**:
  - Update "Running the Application" section to mention progress bar for feed validation.

* **src/main.rs**:
  - Import `indicatif::{ProgressBar, ProgressStyle}`.
  - Initialize progress bar before starting validation tasks in `Commands::Validate` and `Commands::Report`.
  - Update progress bar after each feed validation completes in `Commands::Validate` and `Commands::Report`.
  - Finish progress bar when all validations are done in `Commands::Validate` and `Commands::Report`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/opml-manager/pull/20?shareId=4a9242d1-c058-4d38-ab8b-d738eadbbf16).