### PR TITLE
Escape pipe characters in report

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -161,9 +161,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     for result in status_results {
                         let categories = result.categories.join(" > ");
                         let error = result.error.replace("|", "\\|");
+                        let feed = result.feed.replace("|", "&#124;");
                         report.push_str(&format!(
                             "| {} | {} | {} | {} |\n",
-                            result.feed, result.url, error, categories
+                            feed, result.url, error, categories
                         ));
                     }
                     report.push_str("\n");
@@ -226,9 +227,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 for result in results {
                     if let Ok(Ok(validation)) = result {
                         let error = validation.error.replace("|", "\\|");
+                        let feed = validation.feed.replace("|", "&#124;");
                         report.push_str(&format!(
                             "| {} | {} | {} |\n",
-                            validation.feed, validation.status, error
+                            feed, validation.status, error
                         ));
                     }
                 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -8,6 +8,7 @@ fn escape_special_chars(text: &str) -> String {
         .replace("<", "&lt;")
         .replace(">", "&gt;")
         .replace("\"", "&quot;")
+        .replace("|", "&#124;")
 }
 
 pub fn generate_summary(

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -27,7 +27,7 @@ pub async fn validate_feed(feed: &Feed, client: &Client) -> Result<ValidationRes
             Err(e) => {
                 if e.is_timeout() {
                     return Ok(ValidationResult {
-                        feed: feed.title.clone(),
+                        feed: feed.title.replace("|", "&#124;"),
                         url: feed.xml_url.clone(),
                         status: "error".to_string(),
                         error: "Network timeout".to_string(),
@@ -45,7 +45,7 @@ pub async fn validate_feed(feed: &Feed, client: &Client) -> Result<ValidationRes
                 }
 
                 return Ok(ValidationResult {
-                    feed: feed.title.clone(),
+                    feed: feed.title.replace("|", "&#124;"),
                     url: feed.xml_url.clone(),
                     status: "error".to_string(),
                     error: e.to_string(),
@@ -65,7 +65,7 @@ pub async fn validate_feed(feed: &Feed, client: &Client) -> Result<ValidationRes
                             
                             if is_rss || is_atom {
                                 return Ok(ValidationResult {
-                                    feed: feed.title.clone(),
+                                    feed: feed.title.replace("|", "&#124;"),
                                     url: feed.xml_url.clone(),
                                     status: "valid".to_string(),
                                     error: String::new(),
@@ -74,7 +74,7 @@ pub async fn validate_feed(feed: &Feed, client: &Client) -> Result<ValidationRes
                             }
                             
                             return Ok(ValidationResult {
-                                feed: feed.title.clone(),
+                                feed: feed.title.replace("|", "&#124;"),
                                 url: feed.xml_url.clone(),
                                 status: "invalid".to_string(),
                                 error: "Document is not a valid RSS or Atom feed".to_string(),
@@ -83,7 +83,7 @@ pub async fn validate_feed(feed: &Feed, client: &Client) -> Result<ValidationRes
                         },
                         Err(e) => {
                             return Ok(ValidationResult {
-                                feed: feed.title.clone(),
+                                feed: feed.title.replace("|", "&#124;"),
                                 url: feed.xml_url.clone(),
                                 status: "invalid".to_string(),
                                 error: e.to_string(),
@@ -95,7 +95,7 @@ pub async fn validate_feed(feed: &Feed, client: &Client) -> Result<ValidationRes
                 Err(_) => {
                     if attempts >= max_attempts {
                         return Ok(ValidationResult {
-                            feed: feed.title.clone(),
+                            feed: feed.title.replace("|", "&#124;"),
                             url: feed.xml_url.clone(),
                             status: "error".to_string(),
                             error: "Failed to read response text".to_string(),
@@ -113,7 +113,7 @@ pub async fn validate_feed(feed: &Feed, client: &Client) -> Result<ValidationRes
             continue;
         } else {
             return Ok(ValidationResult {
-                feed: feed.title.clone(),
+                feed: feed.title.replace("|", "&#124;"),
                 url: feed.xml_url.clone(),
                 status: "error".to_string(),
                 error: format!("HTTP {}", response.status()),
@@ -123,7 +123,7 @@ pub async fn validate_feed(feed: &Feed, client: &Client) -> Result<ValidationRes
 
         if attempts >= max_attempts {
             return Ok(ValidationResult {
-                feed: feed.title.clone(),
+                feed: feed.title.replace("|", "&#124;"),
                 url: feed.xml_url.clone(),
                 status: "error".to_string(),
                 error: "Max retry attempts reached".to_string(),


### PR DESCRIPTION
Fixes #24

Escape pipe characters in blog titles to ensure correct rendering in the report table.

* Modify `escape_special_chars` function in `src/report.rs` to handle pipe characters.
* Update `format_markdown_report` function in `src/report.rs` to escape pipe characters in the `feed` field.
* Escape pipe characters in the `feed` field in the `validate_feeds` section of the `Report` command in `src/main.rs`.
* Escape pipe characters in the `feed` field of the `ValidationResult` in the `validate_feed` function in `src/validation.rs`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/opml-manager/pull/25?shareId=5d27d572-253d-466c-a0d3-229284a4ffd3).